### PR TITLE
Update default article settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -213,19 +213,19 @@
       "type": "checkbox",
       "description": "article_author_description",
       "label": "article_author_label",
-      "value": true
+      "value": false
     }, {
       "identifier": "show_article_comments",
       "type": "checkbox",
       "description": "article_comments_description",
       "label": "article_comments_label",
-      "value": true
+      "value": false
     }, {
       "identifier": "show_follow_article",
       "type": "checkbox",
       "description": "follow_article_description",
       "label": "follow_article_label",
-      "value": true
+      "value": false
     }, {
       "identifier": "show_recently_viewed_articles",
       "type": "checkbox",
@@ -243,7 +243,7 @@
       "type": "checkbox",
       "description": "article_sharing_description",
       "label": "article_sharing_label",
-      "value": true
+      "value": false
     }]
   }, {
     "label": "section_page_group_label",


### PR DESCRIPTION
Update some of the default Zendesk settings for articles. By default, turn off:
- article author
- article comments
- follow article
- article sharing