### PR TITLE
feat: improve input field text visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,7 +59,6 @@ textarea {
 }
 
 input {
-  font-weight: 300;
   max-width: 100%;
   box-sizing: border-box;
   outline: none;
@@ -264,8 +263,7 @@ ul {
   text-align: left;
 }
 
-[dir="rtl"] .table th, [dir="rtl"]
-.table th a {
+[dir="rtl"] .table th, [dir="rtl"] .table th a {
   text-align: right;
 }
 
@@ -942,7 +940,7 @@ ul {
   border: 1px solid #ddd;
   border-radius: 8px;
   box-sizing: border-box;
-  color: #999;
+  color: #797676;
   height: 65px;
   font-size: 24px;
   padding-left: 20px;
@@ -1696,13 +1694,8 @@ ul {
   list-style-type: disc;
 }
 
-.article-body a {
-  text-decoration: underline;
-  color: $article_link_color;
-}
-
 .article-body a:visited {
-  color: $visited_article_link_color;
+  color: darken($link_color, 20%);
 }
 
 .article-body code {
@@ -3140,7 +3133,7 @@ ul {
 
 @media (min-width: 1024px) {
   .my-activities-table th:first-child,
-  .my-activities-table td:first-child {
+.my-activities-table td:first-child {
     width: 500px;
   }
 }
@@ -3239,11 +3232,10 @@ ul {
 
 @media (min-width: 768px) {
   .requests-table-toolbar .organization-subscribe,
-  .requests-table-toolbar .organization-unsubscribe {
+.requests-table-toolbar .organization-unsubscribe {
     margin-left: 10px;
   }
-  [dir="rtl"] .requests-table-toolbar .organization-subscribe, [dir="rtl"]
-  .requests-table-toolbar .organization-unsubscribe {
+  [dir="rtl"] .requests-table-toolbar .organization-subscribe, [dir="rtl"] .requests-table-toolbar .organization-unsubscribe {
     margin: 0 10px 0 0;
   }
 }
@@ -3681,6 +3673,8 @@ ul {
 [class^="icon-"]::before,
 [class*=" icon-"]::before,
 .icon,
+.search-result-votes::before,
+.search-result-meta-count::before,
 .search::before,
 .recent-activity-item-comment span::before,
 .article-vote::before,
@@ -3690,9 +3684,7 @@ ul {
 .vote-down::before,
 .actions .dropdown-toggle::before,
 .collapsible-nav-list li[aria-selected="true"]::after,
-.collapsible-sidebar-title::after,
-.search-result-votes::before,
-.search-result-meta-count::before {
+.collapsible-sidebar-title::after {
   font-family: "copenhagen-icons";
   font-style: normal;
   font-weight: normal;

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -255,7 +255,7 @@
     border-radius: 4px;
     color: $text_color;
     display: block;
-    font-weight: $font-weight-light;
+    font-weight: $font-weight-base;
     margin-bottom: 10px;
     padding: 10px;
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -52,7 +52,6 @@ textarea {
 }
 
 input {
-  font-weight: $font-weight-light;
   max-width: 100%;
   box-sizing: border-box;
   outline: none;

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -10,7 +10,7 @@
   li {
     color: $secondary-text-color;
     display: inline;
-    font-weight: $font-weight-light;
+    font-weight: $font-weight-base;
     font-size: $font-size-small;
     max-width: 450px;
     overflow: hidden;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -24,7 +24,7 @@ $border-color: #ddd;
 $button-color: $brand_color;
 
 $input-font-size: 14px;
-$field-text-color: #999;
+$field-text-color: #797676;
 $field-text-focus-color: #555;
 
 // Breakpoints variables


### PR DESCRIPTION
Fixes: https://github.com/mitodl/mitxpro/issues/2507

Description:

Color contrast for some input fields was very low. This PR improves the color contrast and reverts some uncompiled changes.

- New request page fields are adjusted with the existing style of the `Description` field.
- `Search` field text color is also updated.

Testing:

- Follow [this](https://docs.google.com/document/d/1bP-H1thrPn0tyx99cgUDIGbuU2-tuDgsXK6AxSSRvD4/edit) guideline to setup mitxpro-zendesk-theme locally.
- Verify that the input field text is readable.

ScreenShots:

AFTER:
<img width="1141" alt="Screen Shot 2023-03-15 at 3 28 49 PM" src="https://user-images.githubusercontent.com/52656433/225282707-4baa84f0-c8a8-4567-8c90-2bb0a3c1ea26.png">
<img width="1141" alt="Screen Shot 2023-03-15 at 3 29 08 PM" src="https://user-images.githubusercontent.com/52656433/225282717-5e461b60-d3ac-4494-ae7b-67ef21662253.png">
<img width="435" alt="Screen Shot 2023-03-15 at 3 30 38 PM" src="https://user-images.githubusercontent.com/52656433/225282719-9febd104-50de-4a8d-88c1-3e2536ddfd03.png">


BEFORE:
<img width="435" alt="Screen Shot 2023-03-15 at 3 31 43 PM" src="https://user-images.githubusercontent.com/52656433/225282933-e96ab7d0-d4fd-4ac1-be05-bac4a379fd05.png">
<img width="1135" alt="Screen Shot 2023-03-15 at 3 31 58 PM" src="https://user-images.githubusercontent.com/52656433/225282943-eccb7d0f-7a68-4ee0-ad0c-098b40b7fe06.png">
